### PR TITLE
security bug fix: Fix malformed Content-Encoding header in json-status upload

### DIFF
--- a/json-status
+++ b/json-status
@@ -359,7 +359,7 @@ while true; do
     sleep 0.314
 
 	# Push up the data.  'curl' will wait no more than $MAX_CURL_TIME seconds for upload to complete
-	curl -m $MAX_CURL_TIME $CURL_EXTRA -sS -X POST -H "adsbx-uuid: ${UUID}" -H "Content_Encoding: gzip" --data-binary @- $REMOTE_URL 2>&1 <$TEMP_DIR/upload.gz
+	curl -m $MAX_CURL_TIME $CURL_EXTRA -sS -X POST -H "adsbx-uuid: ${UUID}" -H "Content-Encoding: gzip" --data-binary @- $REMOTE_URL 2>&1 <$TEMP_DIR/upload.gz
 	RV=$?
 
 	if [ $RV -ne 0 ]; then


### PR DESCRIPTION
## Summary

Fixes a malformed HTTP header in the `json-status` upload path. The `curl` POST was sending `Content_Encoding: gzip` (underscore) instead of the RFC-compliant `Content-Encoding: gzip` (hyphen).

## Problem

Per [RFC 7230 § 3.2](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2), HTTP header field names must use hyphens. While many servers tolerate underscores via fallback parsing, hardened gateways silently drop them — most notably **nginx, which defaults to `underscores_in_headers off`**.

When the header is dropped:
- The gzipped body is delivered without the `Content-Encoding` flag.
- The server treats the payload as raw bytes and may attempt to gunzip data it doesn't know is compressed (or skip decompression entirely), causing the upload to fail or be misinterpreted.

## Fix

Single-character change in `json-status` (line ~362):

```diff
- -H "Content_Encoding: gzip"
+ -H "Content-Encoding: gzip"