### PR TITLE
bug fix: Fix undefined $CURL variable in curl failure warning message

### DIFF
--- a/json-status
+++ b/json-status
@@ -363,7 +363,7 @@ while true; do
 	RV=$?
 
 	if [ $RV -ne 0 ]; then
-		echo "WARNING: curl process returned non-zero ($RV): [$CURL]; Sleeping a little extra."
+		echo "WARNING: curl process returned non-zero ($RV): [$REMOTE_URL]; Sleeping a little extra."
 		sleep $(( 5 + RANDOM % 15 ))
 	fi
 done


### PR DESCRIPTION
## Summary
Fixes an undefined variable reference in the `json-status` script's curl error handler.

## Problem
At line 366 of `json-status`, when `curl` returns a non-zero exit code, the warning message references `$CURL`, which is never assigned anywhere in the script:

```bash
echo "WARNING: curl process returned non-zero ($RV): [$CURL]; Sleeping a little extra."
#                                                  ^^^^^ never assigned
```

As a result, the diagnostic always prints an empty value ([]), making the warning much less useful for debugging upload failures.

Fix
Replaced $CURL with $REMOTE_URL, which is the actual URL passed to the failing curl invocation a few lines above. The warning now correctly identifies which endpoint failed:

```
echo "WARNING: curl process returned non-zero ($RV): [$REMOTE_URL]; Sleeping a little extra."
```