### PR TITLE
bug fix: Fix set -u-unsafe associative array reads in dns_lookup()

### DIFF
--- a/json-status
+++ b/json-status
@@ -149,8 +149,8 @@ dns_lookup () {
 	fi
 
 	# If the host is cached, and the TTL hasn't expired, return the cached data.
-	if [ ${DNS_LOOKUP[$HOST]} ]; then
-		if [ ${DNS_EXPIRE[$HOST]} -ge $NOW ]; then
+	if [ -n "${DNS_LOOKUP[$HOST]:-}" ]; then
+		if [ "${DNS_EXPIRE[$HOST]:-0}" -ge "$NOW" ]; then
 			return 0
 		fi
 	fi


### PR DESCRIPTION
## Summary

Hardens the DNS cache lookup in `dns_lookup()` (json-status) so it remains
correct under `set -u` and against unset/empty associative-array keys.

## Problem

```bash
if [ ${DNS_LOOKUP[$HOST]} ]; then           # unset key → "[ ]" → works only by luck
    if [ ${DNS_EXPIRE[$HOST]} -ge $NOW ]; then   # unset → "[ -ge 12345 ]" → syntax error
```

An unset key expands to nothing, so the outer test silently degenerates to
[ ] (true). It only behaves "correctly" because of unquoted word-splitting.
If the inner branch were ever reached with an unset/empty DNS_EXPIRE[$HOST],
the numeric comparison would blow up with integer expression expected.
Under set -u (which the script doesn't currently enable), the unset
subscript expansion would abort the script outright.

Fix
Use :- default expansions and quote the operands:
```
if [ -n "${DNS_LOOKUP[$HOST]:-}" ]; then
    if [ "${DNS_EXPIRE[$HOST]:-0}" -ge "$NOW" ]; then
        return 0
    fi
fi
```
${DNS_LOOKUP[$HOST]:-} → safe empty default; -n with quoting gives a
proper "is this cached?" check.
${DNS_EXPIRE[$HOST]:-0} → guarantees a valid integer for -ge, so the
inner test can never produce a syntax error.
Quoting "$NOW" as well, for consistency.