### PR TITLE
feature: Drop perl + bind9-host deps: use getent for DNS lookups

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,9 +22,9 @@ function aptInstall() {
 }
 
 # commands used
-COMMANDS="curl jq gzip host perl"
+COMMANDS="curl jq gzip getent"
 # corresponding packages
-PACKAGES="curl jq gzip bind9-host perl bash-builtins"
+PACKAGES="curl jq gzip libc-bin bash-builtins"
 
 install=0
 if ! [[ -f /usr/lib/bash/sleep ]];
@@ -40,7 +40,7 @@ if [[ $install == 1 ]]; then
     if command -v apt-get &>/dev/null; then
         aptInstall $PACKAGES || true
     elif command -v yum &>/dev/null; then
-        yum install -y curl util-linux jq inotify-tools gzip bind-utils perl || true
+        yum install -y curl util-linux jq inotify-tools gzip glibc-common || true
     fi
 fi
 

--- a/json-status
+++ b/json-status
@@ -159,17 +159,15 @@ dns_lookup () {
 	local LOOP=$DNS_MAX_LOOPS
 
 	while [ $LOOP -ge 1 ]; do
-		# Ok, let's look this hostname up!  Use the first IP returned.
-		#  - XXX : WARNING: This assumed the output format of 'host -v' doesn't change drastically! XXX -
-		#  - Because this uses the "Trying" line, it should work for non-FQDN lookups, too -
+		# Ok, let's look this hostname up!  Use the first IPv4 returned by NSS
+		# (getent is part of glibc, no extra packages required).
 
 		sleep $DNS_WAIT &
-		HOST_IP=$( host -v -W $DNS_WAIT -t a "$HOST" | perl -ne 'if (/^Trying "(.*)"/){$h=$1; next;} if (/^$h\.\s+(\d+)\s+IN\s+A\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/) {$i=$2; last}; END {printf("%s", $i);}' )
-		RV=$?
+		HOST_IP=$( getent ahostsv4 "$HOST" 2>/dev/null | awk '{print $1; exit}' )
 		# If this is empty, something failed.  Sleep some and try again...
-		if [ $RV -ne 0 ] || [ "x$HOST_IP" == "x" ]; then
-			if ping -c1 "$HOST" &>/dev/null && ! host -v -W $DNS_WAIT -t a "$HOST" &>/dev/null; then
-				echo "host not working but ping is, disabling DNS caching!"
+		if [ "x$HOST_IP" == "x" ]; then
+			if ping -c1 "$HOST" &>/dev/null && ! getent ahostsv4 "$HOST" &>/dev/null; then
+				echo "getent not working but ping is, disabling DNS caching!"
 				DNS_CACHE=0
 				return 1
 			fi
@@ -208,13 +206,19 @@ if [ $LOCAL_RESOLVER -ne 0 ]; then
 	fi
 fi
 
-if ! command -v host &>/dev/null || ! command -v perl &>/dev/null; then
-    echo "host command or perl not available, disabling DNS Cache" >&2
+if ! command -v getent &>/dev/null; then
+    echo "getent command not available, disabling DNS Cache" >&2
     DNS_CACHE=0
 fi
 
-VER_OK=$( echo "$CURL_VER" | perl -ne '@v=split(/\./); if ($v[0] == 7) { if ($v[1] >= 22) { printf("1");exit; } else { printf("0");exit; } } if ($v[0] > 7) { pr
-intf("1");exit; } printf("0");exit;')
+# Need curl >= 7.22.0 for --resolve.  Parse "X.Y.Z" with bash arithmetic.
+IFS='.' read -r CURL_MAJOR CURL_MINOR _CURL_PATCH <<<"$CURL_VER"
+if [[ "$CURL_MAJOR" =~ ^[0-9]+$ ]] && [[ "$CURL_MINOR" =~ ^[0-9]+$ ]] \
+	&& { (( CURL_MAJOR > 7 )) || { (( CURL_MAJOR == 7 )) && (( CURL_MINOR >= 22 )); }; }; then
+	VER_OK=1
+else
+	VER_OK=0
+fi
 if [ $VER_OK -ne 1 ]; then
 	echo "WARNING: curl version is too old ($CURL_VER < 7.22.0), not using script's DNS cache."
 	DNS_CACHE=0


### PR DESCRIPTION
## Summary

Removes the `perl` and `bind9-host` runtime dependencies from `json-status` by replacing the two places `perl` was used with pure-bash / glibc equivalents.

## Motivation

The `dns_lookup()` helper pulled in **perl** and **bind9-host** purely to parse one line of `host -v` output:

```bash
HOST_IP=$( host -v -W $DNS_WAIT -t a "$HOST" \
    | perl -ne 'if (/^Trying "(.*)"/){$h=$1; ...' )
```

`getent ahostsv4` (from glibc — already a hard requirement on every supported distro) does the same thing in one line and avoids two install-footprint packages. While I was in there, the only other `perl` invocation — a curl version comparison — was rewritten in bash arithmetic so the dependency could be dropped entirely.

## Changes

### `json-status`
- **`dns_lookup()`**: replaced `host -v ... | perl -ne ...` with:
  ```bash
  HOST_IP=$(getent ahostsv4 "$HOST" 2>/dev/null | awk '{print $1; exit}')
  ```
  The existing `ping`/lookup self-disable fallback is preserved (now compares `ping` vs. `getent` instead of `ping` vs. `host`).
- **Capability check**: the `command -v host || command -v perl` guard is now a single `command -v getent` check.
- **curl version check**: replaced the `perl -ne '@v=split(/\./); ...'` one-liner with a bash `IFS='.' read` + `(( ... ))` comparison. Includes a numeric-regex sanity guard so a malformed version string falls through to "too old" rather than throwing an arithmetic error.

### `install.sh`
- `COMMANDS`: dropped `host perl`, added `getent`.
- `PACKAGES` (apt): dropped `bind9-host perl`, added `libc-bin` (provides `getent`; harmless to list — it's `Essential: yes`, so apt is a no-op when already installed).
- `yum` branch: dropped `bind-utils perl`, added `glibc-common` (provides `getent` on RHEL family).

## Compatibility / risk

- `getent ahostsv4` honors `/etc/nsswitch.conf` and `/etc/hosts`, which is arguably *more* correct than going straight to DNS via `host`. Behavior on a normal feeder (DNS-only resolution) is identical.
- The local-resolver detection (`grep nameserver /etc/resolv.conf | ... 127.x.x.x`) still disables the cache when systemd-resolved / dnsmasq is in front, so cache semantics are unchanged.
- `bash-builtins` was left in `PACKAGES` — script already degrades gracefully if `/usr/lib/bash/sleep` isn't present.

## Verification

- `bash -n json-status && bash -n install.sh` — clean.
- `getent ahostsv4 adsbexchange.com | awk '{print $1; exit}'` returns the same kind of A record the previous `host`/`perl` pipeline produced.
- Curl version comparator tested against `7.21.0`, `7.22.0`, `7.81.0`, `8.4.0`, `6.99.99`, and `garbage` — all classify as expected.